### PR TITLE
Tests require CGI::Expand to run

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,6 +31,7 @@ namespace::clean     = 0.20
 
 [Prereqs / TestRequires]
 Test::Exception = 0
+CGI::Expand     = 0
 
 [GithubMeta]
 [ContributorsFromGit]


### PR DESCRIPTION
JSON::RPC::Common::Marshal::HTTP mentions you need it, or something like it,
for the 'expander' attribute
